### PR TITLE
Added ALLDATA Option to the Curl Verbosity Output

### DIFF
--- a/src/RocketCode/Shopify/api.php
+++ b/src/RocketCode/Shopify/api.php
@@ -248,8 +248,8 @@ class API
             CURLOPT_ENCODING        => '',
             CURLOPT_USERAGENT       => 'RocketCode Shopify API Wrapper',
             CURLOPT_FAILONERROR     => $request['FAILONERROR'],
-            CURLOPT_VERBOSE => 1,
-            CURLOPT_HEADER => 1
+            CURLOPT_VERBOSE         => $request['ALLDATA'],
+            CURLOPT_HEADER          => 1
         );
 
 	    // Checks if DATA is being sent


### PR DESCRIPTION
If you set `ALLDATA` to true then you get the Verbose CURL output as well as the ALLDATA array returned. This serves as a useful flag for those who only want logging of errors and not the CURL process.

This resolves the issue: https://github.com/joshrps/laravel-shopify-API-wrapper/issues/3
